### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -19,7 +19,6 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
@@ -109,5 +108,6 @@
         "linter": "eslint"
       }
     }
-  }
+  },
+  "nxCloudId": "6881249ab136984889a9bf9f"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6839c85863c543e879860d08/workspaces/6881249ab136984889a9bf9f

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.