### PR TITLE
Refactor variable declarations to use const

### DIFF
--- a/apps/backend/src/server.js
+++ b/apps/backend/src/server.js
@@ -132,7 +132,7 @@ app.post("/register", async (req, res) => {
       const user = jwt.verify(token, JWT_SECRET);
       const username = user.name;
 
-      let updateField = {};
+      const updateField = {};
       updateField[`answers.${pageType}`] = answers;
   
       const updatedUser = await User.findOneAndUpdate(

--- a/apps/frontend/src/components/animation.jsx
+++ b/apps/frontend/src/components/animation.jsx
@@ -27,10 +27,10 @@ function Animation({ onAnimationFinish }) {
 
   // update progress ellipse based on percentage
   useEffect(() => {
-    let progressEllipse = document.querySelector('.progress'); // select element
-    let rx = parseFloat(progressEllipse.getAttribute('rx')); 
-    let ry = parseFloat(progressEllipse.getAttribute('ry'));
-    let perimeter = Math.PI * (3 * (rx + ry) - Math.sqrt((3 * rx + ry) * (rx + 3 * ry))); // calculate
+    const progressEllipse = document.querySelector('.progress'); // select element
+    const rx = parseFloat(progressEllipse.getAttribute('rx')); 
+    const ry = parseFloat(progressEllipse.getAttribute('ry'));
+    const perimeter = Math.PI * (3 * (rx + ry) - Math.sqrt((3 * rx + ry) * (rx + 3 * ry))); // calculate
     progressEllipse.style.strokeDasharray = perimeter; // set stroke dash array to perimeter
     progressEllipse.style.strokeDashoffset = perimeter - (percent * perimeter) / 100; // update offset based on percentage
 

--- a/apps/frontend/src/components/animationNoCircleDraw.jsx
+++ b/apps/frontend/src/components/animationNoCircleDraw.jsx
@@ -27,10 +27,10 @@ function AnimationNoCircle({ onAnimationFinish }) {
 
   // useEffect hook to update progress ellipse based on percentage
   useEffect(() => {
-    let progressEllipse = document.querySelector('.progress');
-    let rx = parseFloat(progressEllipse.getAttribute('rx'));
-    let ry = parseFloat(progressEllipse.getAttribute('ry'));
-    let perimeter = Math.PI * (3 * (rx + ry) - Math.sqrt((3 * rx + ry) * (rx + 3 * ry)));
+    const progressEllipse = document.querySelector('.progress');
+    const rx = parseFloat(progressEllipse.getAttribute('rx'));
+    const ry = parseFloat(progressEllipse.getAttribute('ry'));
+    const perimeter = Math.PI * (3 * (rx + ry) - Math.sqrt((3 * rx + ry) * (rx + 3 * ry)));
     progressEllipse.style.strokeDasharray = perimeter;
     progressEllipse.style.strokeDashoffset = perimeter - (percent * perimeter) / 100;
 

--- a/apps/frontend/src/helpers/trayGenerators.js
+++ b/apps/frontend/src/helpers/trayGenerators.js
@@ -80,7 +80,7 @@ const cookiePositions = {
 
   // Function to generate DynamicTray
   export function generateDynamicTray(numCookies, trayW, trayH, cookieW, cookieH, padding, minGap) {
-    let placedCookies = [];
+    const placedCookies = [];
   
     for (let i = 0; i < numCookies; i++) {
       let newCookie;


### PR DESCRIPTION
Replaced 'let' with 'const' for variable declarations in server.js, animation.jsx, animationNoCircleDraw.jsx, and trayGenerators.js where variables are not reassigned. This improves code clarity and enforces immutability where appropriate.